### PR TITLE
add NASA SRTM source, add credential support for sources

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,9 @@ test-results*/
 *.patch
 TestResults*/
 
+#Intellij cache
+.idea/
+
 packages/*
 !packages/repositories.config
 .vs/*

--- a/README.md
+++ b/README.md
@@ -14,8 +14,12 @@ A simple library to load SRTM data and return heights in _meter_ for a given lat
 
 ```csharp
 // create a new srtm data instance.
-// it accepts a folder to download and cache data into.
-var srtmData = new SRTMData(@"/path/to/data/cache");
+// it accepts a folder to download and cache data into in addition to the source you want to use for the data.
+// USGS data is immediately available, but is of a lower resolution.
+var srtmData = new SRTMData(@"/path/to/data/cache", new USGSSource());
+// NASA data is of a higher resolution, but requires creating an account at https://urs.earthdata.nasa.gov/users/new/.
+var credentials = new NetworkCredential("username", "password");
+var srtmData = new SRTMData(@"/path/to/data/cache", new NASASource(credentials));
 
 // get elevations for some locations
 int? elevation = srtmData.GetElevation(47.267222, 11.392778);
@@ -33,7 +37,7 @@ Console.WriteLine("Elevation of Ha Noi {0}m", elevation);
 
 ## Data sources
 
-We implemented one default source of data, the [USGS SRTM](https://dds.cr.usgs.gov/srtm/version2_1/SRTM3/). If you want to add an extra source, we're accepting pull requests, you just need to implement [something like this](https://github.com/itinero/srtm/blob/master/src/SRTM/Sources/USGS/USGSSource.cs).
+We implemented two sources of data, the [USGS SRTM](https://dds.cr.usgs.gov/srtm/version2_1/SRTM3/) and [NASA SRTM](https://e4ftl01.cr.usgs.gov/MEASURES/SRTMGL1.003/). If you want to add an extra source, we're accepting pull requests, you just need to implement [something like this](https://github.com/itinero/srtm/blob/master/src/SRTM/Sources/USGS/USGSSource.cs).
 
 ## We need help!
 

--- a/src/SRTM/ISRTMSource.cs
+++ b/src/SRTM/ISRTMSource.cs
@@ -1,0 +1,38 @@
+﻿// The MIT License (MIT)
+
+// Copyright (c) 2019, Tadas Juščius
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+namespace SRTM
+{   
+    /// <summary>
+    /// SRTM source interface.
+    /// </summary>
+    public interface ISRTMSource
+    {
+        /// <summary>
+        /// Gets SRTM data cell from source.
+        /// </summary>
+        /// <param name="path">Local system path where to save the data to.</param>
+        /// <param name="name">Name of the file to get.</param>
+        /// <returns></returns>
+        bool GetMissingCell(string path, string name);
+    }
+}

--- a/src/SRTM/SRTM.csproj
+++ b/src/SRTM/SRTM.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Library</OutputType>

--- a/src/SRTM/SRTMData.cs
+++ b/src/SRTM/SRTMData.cs
@@ -37,6 +37,7 @@ namespace SRTM
     public class SRTMData : ISRTMData
     {
         private const int RETRIES = 3;
+        private ISRTMSource _source;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="Alpinechough.Srtm.SrtmData"/> class.
@@ -47,11 +48,13 @@ namespace SRTM
         /// <exception cref='DirectoryNotFoundException'>
         /// Is thrown when part of a file or directory argument cannot be found.
         /// </exception>
-        public SRTMData(string dataDirectory)
+        public SRTMData(string dataDirectory, ISRTMSource source)
         {
             if (!Directory.Exists(dataDirectory))
                 throw new DirectoryNotFoundException(dataDirectory);
 
+            _source = source;
+            GetMissingCell = _source.GetMissingCell;
             DataDirectory = dataDirectory;
             DataCells = new List<ISRTMDataCell>();
         }
@@ -64,7 +67,7 @@ namespace SRTM
         /// <summary>
         /// Gets or sets the missing cell delegate.
         /// </summary>
-        public GetMissingCellDelegate GetMissingCell { get; set; } = Sources.USGS.USGSSource.GetMissingCell;
+        public GetMissingCellDelegate GetMissingCell { get; set; }
         
         /// <summary>
         /// Gets or sets the data directory.

--- a/src/SRTM/Sources/NASA/NASASource.cs
+++ b/src/SRTM/Sources/NASA/NASASource.cs
@@ -1,6 +1,9 @@
-﻿// The MIT License (MIT)
+﻿using System.Net;
+using SRTM.Logging;
 
-// Copyright (c) 2017 Alpine Chough Software, Ben Abelshausen
+// The MIT License (MIT)
+
+// Copyright (c) 2019, Tadas Juščius
 
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -20,51 +23,37 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-using SRTM.Logging;
-
-namespace SRTM.Sources.USGS
+namespace SRTM.Sources.NASA
 {
     /// <summary>
-    /// Defines an USGS source of data.
+    /// Defines a NASA source of data.
     /// </summary>
-    public class USGSSource : ISRTMSource
+    public class NASASource : ISRTMSource
     {
+        private NetworkCredential _credentials;
+
+        public NASASource(NetworkCredential credentials)
+        {
+            _credentials = credentials;
+        }
+        
         /// <summary>
         /// The source of the data.
         /// </summary>
-        public const string SOURCE = @"https://dds.cr.usgs.gov/srtm/version2_1/SRTM3/";
-
-        /// <summary>
-        /// The continents to try.
-        /// </summary>
-        public static string[] CONTINENTS = new string[]
-        {
-            "Africa",
-            "Australia",
-            "Eurasia",
-            "Islands",
-            "North_America",
-            "South_America"
-        };
+        public const string SOURCE = @"https://e4ftl01.cr.usgs.gov/MEASURES/SRTMGL1.003/2000.02.11/";
 
         /// <summary>
         /// Gets the missing cell.
         /// </summary>
         public bool GetMissingCell(string path, string name)
         {
-            var filename = name + ".hgt.zip";
-            var local = System.IO.Path.Combine(path, filename);
+            var filename = name + ".SRTMGL1.hgt.zip";
+            var local = System.IO.Path.Combine(path, name + ".hgt.zip");
             
             var Logger = LogProvider.For<SRTMData>();
             Logger.Info("Downloading {0} ...", name);
-            foreach (var continent in CONTINENTS)
-            {
-                if (SourceHelpers.Download(local, SOURCE + continent + "/" + filename))
-                {
-                    return true;
-                }
-            }
-            return false;
+
+            return SourceHelpers.DownloadWithCredentials(_credentials, local, SOURCE + filename);
         }
     }
 }

--- a/src/SRTM/Sources/SourceHelpers.cs
+++ b/src/SRTM/Sources/SourceHelpers.cs
@@ -1,6 +1,7 @@
 ﻿using SRTM.Logging;
 using System;
 using System.IO;
+using System.Net;
 using System.Net.Http;
 
 namespace SRTM.Sources
@@ -8,9 +9,26 @@ namespace SRTM.Sources
     public class SourceHelpers
     {
         /// <summary>
-        /// Donwloads a remote file and stores the data in the local one.
+        /// Downloads a remote file and stores the data in the local one.
         /// </summary>
         public static bool Download(string local, string remote, bool logErrors = false)
+        {
+            var client = new HttpClient();
+            return PerformDownload(client, local, remote, logErrors);
+        }
+
+        /// <summary>
+        /// Downloads a remote file and stores the data in the local one. The given credentials are used for authorization.
+        /// </summary>
+        public static bool DownloadWithCredentials(NetworkCredential credentials, string local, string remote,
+            bool logErrors = false)
+        {
+            HttpClientHandler handler = new HttpClientHandler {Credentials = credentials};
+            var client = new HttpClient(handler);
+            return PerformDownload(client, local, remote, logErrors);
+        }
+
+        private static bool PerformDownload(HttpClient client, string local, string remote, bool logErrors = false)
         {
             var Logger = LogProvider.For<SourceHelpers>();
 
@@ -21,7 +39,6 @@ namespace SRTM.Sources
                     File.Delete(local);
                 }
 
-                var client = new HttpClient();
                 using (var stream = client.GetStreamAsync(remote).Result)
                 using (var outputStream = File.OpenWrite(local))
                 {

--- a/test/SRTM.Tests.Functional/Program.cs
+++ b/test/SRTM.Tests.Functional/Program.cs
@@ -22,6 +22,7 @@
 
 using Serilog;
 using System;
+using SRTM.Sources.USGS;
 
 namespace SRTM.Tests.Functional
 {
@@ -35,7 +36,7 @@ namespace SRTM.Tests.Functional
             Log.Logger = log;
 
             // https://dds.cr.usgs.gov/srtm/version2_1/SRTM3/
-            var srtmData = new SRTMData(@"srtm-cache");
+            var srtmData = new SRTMData(@"srtm-cache", new USGSSource());
 
             int? elevationInnsbruck = srtmData.GetElevation(47.267222, 11.392778);
             Console.WriteLine("Elevation of Innsbruck: {0}m", elevationInnsbruck);


### PR DESCRIPTION
The purpose of this PR is to add a new source - urs.earthdata.nasa.gov

Created an interface for sources, so that it would be possible to pick your source when creating a new SRTMData object.

Additionally, extended the SourceHelpers class to be able to handle both anonymous and authenticated downloads. Since this class is used only in the source classes, it is up to each source implementation to decide if they need credentials or not.

Did not implement tests for the new source, as I was unwilling to hard-code some kind of test account. If this is required, a local parameters file should be used to store credentials, but that is beyond the scope of this PR.