### PR TITLE
add bilinear interpolation support for a smoother result

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,19 @@ Console.WriteLine("Elevation of Kathmandu {0}m", elevation);
 
 elevation = srtmData.GetElevation(21.030673628606102f, 105.853271484375f);
 Console.WriteLine("Elevation of Ha Noi {0}m", elevation);
+
+// if a smoother result is preferred, it is possible to use bilinear interpolation at the cost of some accuracy
+double? smoothElevation = srtmData.GetElevationBilinear(47.267222, 11.392778);
+Console.WriteLine("Elevation of Innsbruck: {0}m", elevation);
+
+smoothElevation = srtmData.GetElevationBilinear(-16.5, -68.15);
+Console.WriteLine("Elevation of La Paz: {0}m", elevation);
+
+smoothElevation = srtmData.GetElevationBilinear(27.702983735525862f, 85.2978515625f);
+Console.WriteLine("Elevation of Kathmandu {0}m", elevation);
+
+smoothElevation = srtmData.GetElevationBilinear(21.030673628606102f, 105.853271484375f);
+Console.WriteLine("Elevation of Ha Noi {0}m", elevation);
 ```
 
 ## Data sources

--- a/src/SRTM/EmptySRTMDataCell.cs
+++ b/src/SRTM/EmptySRTMDataCell.cs
@@ -1,7 +1,5 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.IO;
-using System.Text;
 
 namespace SRTM
 {
@@ -34,6 +32,11 @@ namespace SRTM
         public int Longitude { get; private set; }
 
         public int? GetElevation(double latitude, double longitude)
+        {
+            return null;
+        }
+
+        public double? GetElevationBilinear(double latitude, double longitude)
         {
             return null;
         }

--- a/src/SRTM/ISRTMData.cs
+++ b/src/SRTM/ISRTMData.cs
@@ -40,9 +40,22 @@ namespace SRTM
         /// </returns>
         /// <param name='latitude'></param>
         /// <param name='longitude'></param>
-        /// <exception cref='Exception'>
+        /// <exception cref='System.Exception'>
         /// Represents errors that occur during application execution.
         /// </exception>
         int? GetElevation(double latitude, double longitude);
+        
+        /// <summary>
+        /// Gets the elevation. Data is smoothed using bilinear interpolation.
+        /// </summary>
+        /// <returns>
+        /// The height. Null, if elevation is not available.
+        /// </returns>
+        /// <param name="latitude"></param>
+        /// <param name="longitude"></param>
+        /// <exception cref='System.Exception'>
+        /// Represents errors that occur during application execution.
+        /// </exception>
+        double? GetElevationBilinear(double latitude, double longitude);
     }
 }

--- a/src/SRTM/ISRTMDataCell.cs
+++ b/src/SRTM/ISRTMDataCell.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-
-namespace SRTM
+﻿namespace SRTM
 {
     public interface ISRTMDataCell
     {
@@ -11,5 +7,7 @@ namespace SRTM
         int Longitude { get; }
 
         int? GetElevation(double latitude, double longitude);
+        
+        double? GetElevationBilinear(double latitude, double longitude);
     }
 }

--- a/src/SRTM/SRTMDataCell.cs
+++ b/src/SRTM/SRTMDataCell.cs
@@ -43,7 +43,7 @@ namespace SRTM
         #region Lifecycle
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="Alpinechough.Srtm.SrtmDataCell"/> class.
+        /// Initializes a new instance of the <see cref="SRTM.SRTMDataCell"/> class.
         /// </summary>
         /// <param name='filepath'>
         /// Filepath.
@@ -161,6 +161,61 @@ namespace SRTM
         {
             int localLat = (int)((latitude - Latitude) * PointsPerCell);
             int localLon = (int)(((longitude - Longitude)) * PointsPerCell);
+            return ReadByteData(localLat, localLon);
+        }
+        
+        /// <summary>
+        /// Gets the elevation. Data is smoothed using bilinear interpolation.
+        /// </summary>
+        /// <returns>
+        /// The height. Null, if elevation is not available.
+        /// </returns>
+        /// <param name='latitude'></param>
+        /// <param name='longitude'></param>
+        /// <exception cref='Exception'>
+        /// Represents errors that occur during application execution.
+        /// </exception>
+        public double? GetElevationBilinear(double latitude, double longitude)
+        {
+            double localLat = (latitude - Latitude) * PointsPerCell;
+            double localLon = (longitude - Longitude) * PointsPerCell;
+
+            int localLatMin = (int) Math.Floor(localLat);
+            int localLonMin = (int) Math.Floor(localLon);
+            int localLatMax = (int) Math.Ceiling(localLat);
+            int localLonMax = (int) Math.Ceiling(localLon);
+
+            int? elevation00 = ReadByteData(localLatMin, localLonMin);
+            int? elevation10 = ReadByteData(localLatMax, localLonMin);
+            int? elevation01 = ReadByteData(localLatMin, localLonMax);
+            int? elevation11 = ReadByteData(localLatMax, localLonMax);
+
+            if (!elevation00.HasValue || !elevation10.HasValue || !elevation01.HasValue || !elevation11.HasValue)
+            {
+                //Can't do bilinear if missing one of the points. Default to regular.
+                return (double)GetElevation(latitude, longitude);
+            }
+            
+            double deltaLat = localLatMax - localLat;
+            double deltaLon = localLonMax - localLon;
+
+            return Blerp((double) elevation00, (double) elevation10, (double) elevation01, (double) elevation11,
+                deltaLat, deltaLon);
+        }
+
+        #endregion
+        
+        #region Private Methods
+
+        /// <summary>
+        /// Method responsible for reading byte data from data cell file.
+        /// </summary>
+        /// <param name="localLat">Local latitude within the data cell</param>
+        /// <param name="localLon">Local longitude within the data cell</param>
+        /// <returns>Height read from data cell file</returns>
+        /// <exception cref="ArgumentOutOfRangeException"></exception>
+        private int? ReadByteData(int localLat, int localLon)
+        {
             int bytesPos = ((PointsPerCell - localLat - 1) * PointsPerCell * 2) + localLon * 2;
 
             if (bytesPos < 0 || bytesPos > PointsPerCell * PointsPerCell * 2)
@@ -176,6 +231,16 @@ namespace SRTM
             return (HgtData[bytesPos]) << 8 | HgtData[bytesPos + 1];
         }
 
+        private double Lerp(double start, double end, double delta)
+        {
+            return start + (end - start) * delta;
+        }
+
+        private double Blerp(double val00, double val10, double val01, double val11, double deltaX, double deltaY)
+        {
+            return Lerp(Lerp(val11, val01, deltaX), Lerp(val10, val00, deltaX), deltaY);
+        }
+        
         #endregion
     }
 }

--- a/test/SRTM.Tests.Functional/Program.cs
+++ b/test/SRTM.Tests.Functional/Program.cs
@@ -35,6 +35,17 @@ namespace SRTM.Tests.Functional
                 .CreateLogger();
             Log.Logger = log;
 
+            USGSTest();
+            BilinearInterpolationTest();
+            
+            Console.WriteLine("Testing finished.");
+            Console.ReadLine();
+        }
+
+        static void USGSTest()
+        {
+            Console.WriteLine("Start USGSTest.");
+            
             // https://dds.cr.usgs.gov/srtm/version2_1/SRTM3/
             var srtmData = new SRTMData(@"srtm-cache", new USGSSource());
 
@@ -45,7 +56,7 @@ namespace SRTM.Tests.Functional
             Console.WriteLine("Elevation of La Paz: {0}m", elevationLaPaz);
 
             int? elevationKathmandu = srtmData.GetElevation(27.702983735525862f, 85.2978515625f);
-            Console.WriteLine("Elevation of Kathmandu {0}m", elevationLaPaz);
+            Console.WriteLine("Elevation of Kathmandu {0}m", elevationKathmandu);
 
             int? elevationHanoi = srtmData.GetElevation(21.030673628606102f, 105.853271484375f);
             Console.WriteLine("Elevation of Ha Noi {0}m", elevationHanoi);
@@ -57,8 +68,40 @@ namespace SRTM.Tests.Functional
             int? elevationNamibia1 = srtmData.GetElevation(-20, 19.89597);
             Console.WriteLine("Elevation of namibia1 returns {0}", elevationNamibia1);
 
-            Console.WriteLine("Testing finished.");
-            Console.ReadLine();
+            Console.WriteLine("End USGSTest.");
+        }
+
+        static void BilinearInterpolationTest()
+        {
+            Console.WriteLine("Start BilinearInterpolationTest.");
+            
+            // https://dds.cr.usgs.gov/srtm/version2_1/SRTM3/
+            var srtmData = new SRTMData(@"srtm-cache", new USGSSource());
+
+            double? elevationInnsbruck = srtmData.GetElevationBilinear(47.267222, 11.392778);
+            Console.WriteLine("Bilinear elevation of Innsbruck: {0}m", elevationInnsbruck);
+
+            double? elevationLaPaz = srtmData.GetElevationBilinear(-16.5, -68.15);
+            Console.WriteLine("Elevation of La Paz: {0}m", elevationLaPaz);
+
+            double? elevationKathmandu = srtmData.GetElevationBilinear(27.702983735525862f, 85.2978515625f);
+            Console.WriteLine("Elevation of Kathmandu {0}m", elevationKathmandu);
+
+            double? elevationHanoi = srtmData.GetElevationBilinear(21.030673628606102f, 105.853271484375f);
+            Console.WriteLine("Elevation of Ha Noi {0}m", elevationHanoi);
+
+            // tries to get elevation from an empty cell.
+            double? elevationSomeplace1 = srtmData.GetElevationBilinear(52.02237f, 2.55853224f);
+            Console.WriteLine("Elevation of nowhere returns {0}", elevationSomeplace1);
+
+            double? elevationNamibia1 = srtmData.GetElevationBilinear(-20, 19.89597);
+            Console.WriteLine("Elevation of namibia1 returns {0}", elevationNamibia1);
+            
+            //Testing interpolation across cell edges
+            double? elevationOxted = srtmData.GetElevationBilinear(51.2525, 0.00001);
+            Console.WriteLine("Elevation of Oxted {0}m", elevationOxted);
+
+            Console.WriteLine("End BilinearInterpolationTest.");
         }
     }
 }


### PR DESCRIPTION
The purpose of this PR is to add a method to get elevation using bi-linear interpolation.

This PR should close #5 

Before and after shots, when using a 1 arc second data set and querying for elevation roughly every 0.3 arc seconds. Area is roughly 1 square kilometer:
![elevation raw](https://user-images.githubusercontent.com/15195221/70851946-8d298600-1ea4-11ea-8e30-64b19c6e01de.PNG)
![elevation bilinear](https://user-images.githubusercontent.com/15195221/70851948-90bd0d00-1ea4-11ea-9e90-79676ba8f587.PNG)

I chose to restructure some of the code to prevent unnecessary duplication. The data cell downloading was moved into it's own method. Retries are now done recursively. File byte reading was also moved into it's own method.

Code available at [Rosetta Code](https://rosettacode.org/wiki/Bilinear_interpolation) was used for the actual interpolation implementation.

Finally, my IDE was complaining about a few mismatches in some of the method documentation, so I've updated where necessary.